### PR TITLE
[BUGFIX] [IE11] point _crypto private variable to window.msCrypto if !window.crypto

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,4 +39,3 @@ Verified RFC-4122 compliance.
 1.0.8
 
 - Add fix for IE11 when using crypto library (check window.msCrypto)
-- Refactor assigning the _crypto variable by environment

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,3 +39,4 @@ Verified RFC-4122 compliance.
 1.0.8
 
 - Add fix for IE11 when using crypto library (check window.msCrypto)
+- Refactor assigning the _crypto variable by environment

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,3 +35,7 @@ Verified RFC-4122 compliance.
 - Fixes browser support for crypto.getRandomValues()
 - Fixes typo
 - Thanks to [@dlongley](https://github.com/dlongley)
+
+1.0.8
+
+- Add fix for IE11 when using crypto library (check window.msCrypto)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Random (v4) UUIDs are often
 clock-based (v1), but `Math.random()`
 [sucks](https://medium.com/@betable/tifu-by-using-math-random-f1c308c4fd9d)
 [for](http://devoluk.com/google-chrome-math-random-issue.html)
-[uuid generation](http://stackoverflow.com/quTestions/6906916/collisions-when-generating-uuids-in-javascript).
+[uuid generation](http://stackoverflow.com/questions/6906916/collisions-when-generating-uuids-in-javascript).
 
 After digging through [npm](https://www.npmjs.com/search?q=uuid)
 I settled on using [node-uuid](https://github.com/broofa/node-uuid) to take

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Random (v4) UUIDs are often
 clock-based (v1), but `Math.random()`
 [sucks](https://medium.com/@betable/tifu-by-using-math-random-f1c308c4fd9d)
 [for](http://devoluk.com/google-chrome-math-random-issue.html)
-[uuid generation](http://stackoverflow.com/questions/6906916/collisions-when-generating-uuids-in-javascript).
+[uuid generation](http://stackoverflow.com/quTestions/6906916/collisions-when-generating-uuids-in-javascript).
 
 After digging through [npm](https://www.npmjs.com/search?q=uuid)
 I settled on using [node-uuid](https://github.com/broofa/node-uuid) to take

--- a/index.js
+++ b/index.js
@@ -27,23 +27,36 @@
     hexBytes[i] = (i + 0x100).toString(16).substr(1);
   }
 
-  // Node & Browser support
   var _crypto;
-  if(typeof crypto !== 'undefined') {
-    _crypto = crypto;
-  } else if (window.crypto) {
-    _crypto = window.crypto;
-  } else if (window.msCrypto) {
-    _crypto = window.msCrypto;
-  } else {
-    throw new Error('Non-standard crypto library');
+  setEnvironment();
+  function setEnvironment() {
+    if(isNodeEnvironment) {
+      _crypto = _crypto || require('crypto');
+      module.exports = uuid;
+      return;
+    }
+    else if(isBrowserEnvironment) {
+      window.uuid = uuid;
+
+      if(typeof window.crypto !== 'undefined') {
+        _crypto = crypto;
+        return;
+      } else if (window.msCrypto) {
+        // IE11
+        _crypto = window.msCrypto;
+        return;
+      } else {
+        throw new Error('Non-standard crypto library');
+      }
+    }
   }
 
-  if ((typeof module !== 'undefined') && (typeof require === 'function')) {
-    _crypto = _crypto || require('crypto');
-    module.exports = uuid;
-  } else if (typeof window !== 'undefined') {
-    window.uuid = uuid;
+  function isNodeEnvironment() {
+    return ((typeof module !== 'undefined') && (typeof require === 'function'));
+  }
+
+  function isBrowserEnvironment() {
+    return typeof window !== 'undefined';
   }
 
   // Backup method

--- a/index.js
+++ b/index.js
@@ -31,7 +31,14 @@
   var _crypto;
   if(typeof crypto !== 'undefined') {
     _crypto = crypto;
+  } else if (window.crypto) {
+    _crypto = window.crypto;
+  } else if (window.msCrypto) {
+    _crypto = window.msCrypto;
+  } else {
+    throw new Error('Non-standard crypto library');
   }
+
   if ((typeof module !== 'undefined') && (typeof require === 'function')) {
     _crypto = _crypto || require('crypto');
     module.exports = uuid;

--- a/index.js
+++ b/index.js
@@ -27,36 +27,20 @@
     hexBytes[i] = (i + 0x100).toString(16).substr(1);
   }
 
+  // Node & Browser support
   var _crypto;
-  setEnvironment();
-  function setEnvironment() {
-    if(isNodeEnvironment) {
-      _crypto = _crypto || require('crypto');
-      module.exports = uuid;
-      return;
-    }
-    else if(isBrowserEnvironment) {
-      window.uuid = uuid;
+  if(typeof crypto !== 'undefined') {
+    _crypto = crypto;
+  } else if( (typeof window !== 'undefined') && (typeof window.msCrypto !== 'undefined')) {
+    // IE11
+    _crypto = window.msCrypto;
+  } 
 
-      if(typeof window.crypto !== 'undefined') {
-        _crypto = crypto;
-        return;
-      } else if (window.msCrypto) {
-        // IE11
-        _crypto = window.msCrypto;
-        return;
-      } else {
-        throw new Error('Non-standard crypto library');
-      }
-    }
-  }
-
-  function isNodeEnvironment() {
-    return ((typeof module !== 'undefined') && (typeof require === 'function'));
-  }
-
-  function isBrowserEnvironment() {
-    return typeof window !== 'undefined';
+  if ((typeof module !== 'undefined') && (typeof require === 'function')) {
+    _crypto = _crypto || require('crypto');
+    module.exports = uuid;
+  } else if (typeof window !== 'undefined') {
+    window.uuid = uuid;
   }
 
   // Backup method

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uuid-random",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Fastest UUIDv4 with good RNG",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hello!

When using uuid-random in IE11, the function, `randomBytes`, resulting in an error thrown:

> Non-standard crypto library

Internet Explorer being Internet Explorer, the cause of this is that in IE11 the `window.crypto` object is available as window.msCrypto`.

This PR updates the check for crypto to:
````
  var _crypto;
  setEnvironment();
  function setEnvironment() {
    if(isNodeEnvironment) {
      _crypto = _crypto || require('crypto');
      module.exports = uuid;
      return;
    }
    else if(isBrowserEnvironment) {
      window.uuid = uuid;

      if(typeof window.crypto !== 'undefined') {
        _crypto = crypto;
        return;
      } else if (window.msCrypto) {
        // IE11
        _crypto = window.msCrypto;
        return;
      } else {
        throw new Error('Non-standard crypto library');
      }
    }
  }


  function isNodeEnvironment() {
    return ((typeof module !== 'undefined') && (typeof require === 'function'));
  }

  function isBrowserEnvironment() {
    return typeof window !== 'undefined';
  }
````

That is: 
First, check if the code is executing in a Node environment. If not, then check for the browser environment via the `window` object. If the check for `window.crypto` fails, then check for `window.msCrypto`.
Else, throw the 'Non-standard crypto library' error. 

Please note [another PR by the OG author](https://github.com/jchook/uuid-random/pull/6/files) that would conflict with this PR as it has some refactors to how the `_crypto` var is assigned. 

 
This was tested in: 
- Chrome 73.0.3683.86 (on OS X)
- Firefox 66.0.1 (on OS X)
- Node v10.15.3 (on OS X)
- IE11 v11.0.9600.18860 (on a Windows 7 VirtualBox from [Modern.ie](https://modern.ie) )
- IE11 v11.648.17134.0 (on Windows 10)