### PR TITLE
chore: update benchmark with crypto's randomUUID

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -13,6 +13,7 @@ var id128 = require('id128')
 
 suite
   .add('uuid-random', require('..'))
+  .add('crypto', require('crypto').randomUUID)
   .add('id128', function () { id128.Uuid4.generate().toCanonical() })
   .add('portable-uuid', require('portable-uuid'))
   .add('uuid', require('uuid').v4)


### PR DESCRIPTION
Node.js 14.17.0 introduced `randomUUID` in the `crypto` module. This PR adds it to the benchmark.